### PR TITLE
Adding options for default_dir, resource_root, and root_dir

### DIFF
--- a/apper/Fusion360CommandBase.py
+++ b/apper/Fusion360CommandBase.py
@@ -82,19 +82,10 @@ class Fusion360CommandBase:
 
         drop_down_folder = options.get('drop_down_resources', 'demo_icons')
         resources_folder = options.get('cmd_resources', 'demo_icons')
-        #
-        # self.path = os.path.dirname(
-        #     os.path.relpath(
-        #         sys.modules[self.__class__.__module__].__file__,
-        #         self.fusion_app.root_path
-        #     )
-        # )
-        #
-        # resource_path = os.path.join(self.fusion_app.root_path, self.path, 'resources', resources_folder)
-        # drop_resources_path = os.path.join(self.fusion_app.root_path, self.path, 'resources', drop_down_folder)
 
-        resource_path = os.path.join('commands', 'resources', resources_folder)
-        drop_resources_path = os.path.join('commands', 'resources', drop_down_folder)
+        resource_root = options.get('resource_root', os.path.join('commands', 'resources'))
+        resource_path = os.path.join(resource_root, resources_folder)
+        drop_resources_path = os.path.join(resource_root, drop_down_folder)
 
         self.cmd_resources = resource_path
         self.drop_down_resources = drop_resources_path

--- a/apper/FusionApp.py
+++ b/apper/FusionApp.py
@@ -26,9 +26,12 @@ class FusionApp:
         name: The name of the addin
         company: the name of your company or organization
         debug: set this flag as True to enable more interactive feedback when developing.
+        default_dir: the base config directory (default: $HOME)
+        resource_dir: the resource directory relative to root_dir (default: 'commands/resources')
+        root_path: the root directory of the app (default: '')
     """
 
-    def __init__(self, name: str, company: str, debug: bool):
+    def __init__(self, name: str, company: str, debug: bool, **kwargs):
         self.name = name
         self.company = company
         self.debug = debug
@@ -36,9 +39,10 @@ class FusionApp:
         self.events = []
         self.features = []
         self.tabs = []
-        self.default_dir = self._get_default_dir()
+        self.default_dir = kwargs.get('default_dir', self._get_default_dir())
         self.preferences = self.get_all_preferences()
-        self.root_path = ''
+        self.resource_root = kwargs.get('resource_dir', os.path.join('commands', 'resources'))
+        self.root_path = kwargs.get('root_path', '')
         self.command_dict = {}
         self.custom_toolbar_tab = True
         self.logger: Optional[logging.Logger] = None
@@ -67,6 +71,7 @@ class FusionApp:
 
             options['app_name'] = self.name
             options['fusion_app'] = self
+            options['resource_root'] = self.resource_root
 
             tab_id = options.get('toolbar_tab_id', None)
             tab_name = options.get('toolbar_tab_name', None)
@@ -404,5 +409,3 @@ class FusionApp:
         handler.setFormatter(formatter)
         self.logger.addHandler(handler)
         self.logging_enabled = True
-
-


### PR DESCRIPTION
I'm working on an app which has a slightly different directory structure
than the one expected by this library. In particular, I'd like the
resources directory to be off the root of the project, and the
preferences directory to be in `~/.config/<my-addin>`.

This PR doesn't make those changes, which would be subjective and
represent a breaking change. Instead I've made default_dir configurable
via kwargs to the app constructor. I've also added a new option for
`resource_root`, which defaults to _command/resources_ to avoid any
breaking changes for existing add ins.

@tapnair 